### PR TITLE
Fix refresh opt in occm

### DIFF
--- a/addons/openstack-cloud-controller-manager/enable
+++ b/addons/openstack-cloud-controller-manager/enable
@@ -24,6 +24,7 @@ NAMESPACE = "occm"
 def set_external_provider():
     subprocess.check_call(
         [
+            "/bin/bash",
             os.path.expandvars("$SNAP/actions/common/utils.sh"),
             "refresh_opt_in_config",
             "cloud-provider",


### PR DESCRIPTION
Call `/bin/bash` from subprocess before calling refresh opt